### PR TITLE
add instructions

### DIFF
--- a/demo/demo_hsc_config.ipynb
+++ b/demo/demo_hsc_config.ipynb
@@ -37,6 +37,7 @@
     "3. Setup environment variables. \n",
     "    - For PDR, please use: `SSP_PDR_USR` and `SSP_PDR_PWD`\n",
     "    - For IDR, please use: `SSP_IDR_USR` and `SSP_IDR_PWD`\n",
+    "    - To permanently save your username and password to environment variables, you can open `~/.bash_profile` (or `~/.bashrc`) and write `export SSP_PDR_USR='xxx'`, `export SSP_PDR_PWD='yyy'`. To make them take effect, do `$. ~/.bash_profile` (or `$. ~/.bashrc`).\n",
     "    \n",
     "### Data Release: `DR`\n",
     "\n",
@@ -344,7 +345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   },
   "nav_menu": {},
   "toc": {


### PR DESCRIPTION
 I added instructions of exporting username and password to environment variables. Btw, python 3.6.8 cannot use `from __future__ import annotation`  in your `sky.py`.