### PR TITLE
Implements bulk download of postage stamps from HSC server

### DIFF
--- a/bin/hsc_bulk_cutout
+++ b/bin/hsc_bulk_cutout
@@ -11,10 +11,10 @@ def main():
                       help='Filters to extract, (default: griz)')
     parser.add_argument('-s', '--size', dest='cutout_size', type=float, default=10.,
                       help='Size of the cutouts, in arcsec (default 10)')
-    parser.add_argument('-d','--data_release', dest='dr', type=str, default='dr2',
-                      help='Data release to query (default: dr2)')
-    parser.add_argument('-r','--rerun', dest='rerun', type=str, default='s18a_wide',
-                      help='Rerun to query (default: s18a_wide)')
+    parser.add_argument('-d','--data_release', dest='dr', type=str, default='pdr2',
+                      help='Data release to query (default: pdr2)')
+    parser.add_argument('-r','--rerun', dest='rerun', type=str, default='pdr2_dud',
+                      help='Rerun to query (default: pdr2_dud)')
     parser.add_argument('-t', '--img_type', dest='img_type', type=str, default='coadd',
                       help='Type of images to extract (default: coadd)')
     parser.add_argument('--tmp_dir', dest='tmp_dir', type=str, default=None,
@@ -31,12 +31,12 @@ def main():
     catalog = Table.read(args.catalog)
     # Downloads the data
     output_file = hsc_bulk_cutout(catalog, cutout_size=args.cutout_size,
-                    filters=list(args.filters), dr=args.data_release,
+                    filters=list(args.filters), dr=args.dr,
                     rerun=args.rerun, img_type=args.img_type,
                     tmp_dir=args.tmp_dir, nproc=args.nproc,
                     output_dir=args.output_dir, overwrite=args.overwrite)
     print("Downloaded cutouts available at: ", output_file)
 
 
-if__name__== "__main__":
+if __name__== "__main__":
     main()

--- a/bin/hsc_bulk_cutout
+++ b/bin/hsc_bulk_cutout
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import unagi
 from unagi.task import hsc_bulk_cutout

--- a/bin/hsc_bulk_cutout.py
+++ b/bin/hsc_bulk_cutout.py
@@ -1,0 +1,41 @@
+import argparse
+import unagi
+from unagi.task import hsc_bulk_cutout
+from astropy.table import Table
+
+def main():
+    # Parse options and arguments
+    parser = argparse.ArgumentParser(description='Downloads in bulk cutouts from the HSC survey.')
+    parser.add_argument('-f', '--filters', dest='filters', type=str, default='griz',
+                      help='Filters to extract, (default: griz)')
+    parser.add_argument('-s', '--size', dest='cutout_size', type=float, default=10.,
+                      help='Size of the cutouts, in arcsec (default 10)')
+    parser.add_argument('-d','--data_release', dest='dr', type=str, default='dr2',
+                      help='Data release to query (default: dr2)')
+    parser.add_argument('-r','--rerun', dest='rerun', type=str, default='s18a_wide',
+                      help='Rerun to query (default: s18a_wide)')
+    parser.add_argument('-t', '--img_type', dest='img_type', type=str, default='coadd',
+                      help='Type of images to extract (default: coadd)')
+    parser.add_argument('--tmp_dir', dest='tmp_dir', type=str, default=None,
+                      help='Temporary directory where data is downloaded and extracted.')
+    parser.add_argument('-n', '--nproc', dest='nproc', type=int, default=1,
+                       help='Number of concurrent download processes (default: 1)')
+    parser.add_argument('-o', '--overwrite', dest='overwrite', action='store_true', default=False,
+                      help='Automatically overwrite output files if already exist')
+    parser.add_argument('catalog', help='Input catalog of object_ids and ra,dec coordinates')
+    parser.add_argument('output_dir', help='output_directory')
+    args = parser.parse_args()
+
+    # Loads the table
+    catalog = Table.read(args.catalog)
+    # Downloads the data
+    output_file = hsc_bulk_cutout(catalog, cutout_size=args.cutout_size,
+                    filters=list(args.filters), dr=args.data_release,
+                    rerun=args.rerun, img_type=args.img_type,
+                    tmp_dir=args.tmp_dir, nproc=args.nproc,
+                    output_dir=args.output_dir, overwrite=args.overwrite)
+    print("Downloaded cutouts available at: ", output_file)
+
+
+if__name__== "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 pyparsing
 astropy>=3.0
 matplotlib>=2.0
+fits2hdf>=1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pyparsing
 astropy>=3.0
 matplotlib>=2.0
 fits2hdf>=1.1.1
-retrying>=1.3.3
+tenacity>=5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyparsing
 astropy>=3.0
 matplotlib>=2.0
 fits2hdf>=1.1.1
+retrying>=1.3.3

--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.6',
+    scripts=['bin/hsc_bulk_cutout'],
 )

--- a/unagi/hsc.py
+++ b/unagi/hsc.py
@@ -9,6 +9,8 @@ import time
 import urllib
 import shutil
 import warnings
+import tempfile
+import requests
 
 import numpy as np
 
@@ -137,6 +139,10 @@ class Hsc():
         if password is None:
             password = self.archive._password
 
+        # Creates a requests session
+        self.request_session = requests.Session()
+        self.request_session.auth = (username, password)
+
         # Create a password manager
         password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
 
@@ -169,6 +175,70 @@ class Hsc():
             self.opener = None
             self.is_login = False
 
+    def download_bulk_cutouts(self, coord, ouput_dir=None, w_half=None, h_half=None,
+                              filt=['HSC-I'], img_type='coadd',
+                              image=True, variance=False, mask=False,
+                              tmp_dir=None, nproc=None):
+        """
+        Download cutouts in bulk.
+
+        Saves all downloaded fits files into designated output_dir
+
+        Parameters
+        ----------
+        coord: astropy.table.Table
+            Astropy table with ra and dec columns
+        filt: list of str
+            List of filters to request images from
+        output_dir: str
+            Directory where to save all downloaded fits files
+
+        Returns
+        -------
+        cutouts: astropy.table.Table
+            Returns aggregated astropy table of cutouts, with image, variance,
+            and mask entries as requested.
+        """
+        if tmp_dir is None:
+            tmp_dir = mkdtemp()
+
+        # Compute the number of batches to download
+        # There is a hard limit of 1000 cutouts at a time
+        batch_size = 1000
+        n_batches = len(coord) / batch_size
+
+        def get_cutouts(i):
+            """
+            Downloads the cutouts for given filter
+            """
+            # Loop over batches
+            for f in filters:
+                # Generate a list file
+                list_table = coord[['ra', 'dec']][i*batch_size:(i+1)*batch_size]
+                list_table['sw'] = "5.5asec"
+                list_table['sh'] = "5.5asec"
+                list_table['filter'] = f
+                list_table['rerun'] = "pdr1_wide"
+                list_table['#?'] = " "
+                list_table = list_table[['#?', 'ra', 'dec', 'sw', 'sh', 'filter', 'rerun']]
+
+                list_table.write('list_%d.txt'%i, format='ascii.tab')
+
+                process = subprocess.Popen(["./download_list.sh", '%d'%i], stdout=subprocess.PIPE)
+                output, error = process.communicate()
+
+                output = output.split()
+                if len(output) != batch_size:
+                    raise ValueError('A very specific bad thing happened')
+
+                object_id = data['object_id'][i*batch_size:(i+1)*batch_size]
+
+                # Renaming and moving all downloaded images
+                for j, o in enumerate(output):
+                    os.rename(('%d/'%i)+o, f+'/%d.fits'%object_id[j])
+
+
+
     def download_cutout(self, coord, output_file, coord_2=None, w_half=None, h_half=None,
                         filt='HSC-I', img_type='coadd', image=True, variance=False, mask=False,
                         overwrite=True):
@@ -197,6 +267,7 @@ class Hsc():
             return cutout_url
         else:
             raise HscException("# Wrong image type: coadd or warp !")
+
     def download_patch(self, tract, patch, filt='HSC-I', output_file=None, overwrite=True, verbose=True):
         """
         Download coadded image for a single patch.
@@ -208,7 +279,7 @@ class Hsc():
         filt (str): filter name, such as 'HSC-I'
         """
         # Download FITS file for coadd image.
-        
+
         patch_url = self._form_patch_url(tract, patch, filt)
         try:
             if verbose:
@@ -217,7 +288,7 @@ class Hsc():
         except urllib.error.HTTPError as e:
             print("# Error message: {}".format(e))
             raise Exception("# Can not download cutout: {}".format(patch_url))
-        
+
         if output_file is None:
             output_file = '_'.join((self.dr, self.rerun, str(tract), str(patch), filt[-1].lower() + '.fits'))
         _ = cutout.writeto(output_file, overwrite=overwrite)

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -416,7 +416,7 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
     #  Downloading mutliple batches of data in parallel
     print("Starting download of %d batches ..."%n_batches)
     with Pool(nproc) as pool:
-        temp_files = pool.map(download_cutouts, batches)
+        temp_files = pool.map(download_cutouts, batches, chunk_size=1)
     print("Download finalized, aggregating cutouts.")
 
     # At this point, we have a bunch of individual HDF files, we just need to

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -4,6 +4,7 @@
 import os
 import shutil
 import tempfile
+import time
 import glob
 from collections.abc import Iterable
 
@@ -430,7 +431,7 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
     #  Downloading mutliple batches of data in parallel
     print("Starting download of %d batches ..."%n_batches)
     with Pool(nproc) as pool:
-        temp_files = pool.map(download_cutouts, batches, chunk_size=1)
+        temp_files = pool.map(download_cutouts, batches, chunksize=1)
     print("Download finalized, aggregating cutouts.")
 
     # At this point, we have a bunch of individual HDF files, we just need to

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -309,8 +309,6 @@ def _download_cutouts(args, url=None, filters=None, tmp_dir=None,
         # Untar the archive and remove file
         with tarfile.TarFile(os.path.join(tmp_dir, output_filename), "r") as tarball:
             tarball.extractall(tmp_dir)
-        os.remove(os.path.join(tmp_dir, output_filename))
-        os.remove(filename)
 
         # Recover path to output dir
         output_path = os.path.join(tmp_dir, output_filename.split('.tar')[0])
@@ -325,6 +323,10 @@ def _download_cutouts(args, url=None, filters=None, tmp_dir=None,
             export_hdf(a, output_filename)
             # Removing converted file
             os.remove(fname)
+
+        # Remove downloaded tar file and corresponding file  list
+        os.remove(os.path.join(tmp_dir, output_filename))
+        os.remove(filename)
 
     # At this stage all filters have been  downloaded for this batch, now
     # aggregating all of them into a single HDF file

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -311,6 +311,9 @@ def _download_cutouts(args, url=None, filters=None, tmp_dir=None,
         with tarfile.TarFile(os.path.join(tmp_dir, output_filename), "r") as tarball:
             tarball.extractall(tmp_dir)
 
+        os.remove(filename)
+        os.remove(os.path.join(tmp_dir, output_filename))
+
         # Recover path to output dir
         output_path = os.path.join(tmp_dir, output_filename.split('.tar')[0])
         output_paths[filt] = output_path
@@ -324,10 +327,6 @@ def _download_cutouts(args, url=None, filters=None, tmp_dir=None,
             export_hdf(a, output_filename)
             # Removing converted file
             os.remove(fname)
-
-        # Remove downloaded tar file and corresponding file  list
-        os.remove(os.path.join(tmp_dir, output_filename))
-        os.remove(filename)
 
     # At this stage all filters have been  downloaded for this batch, now
     # aggregating all of them into a single HDF file

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 from collections.abc import Iterable
 
+import requests
 import tarfile
 import numpy as np
 import astropy.units as u
@@ -314,6 +315,10 @@ def hsc_cutout_bulk_download(table, cutout_size=10.0 * u.Unit('arcsec'),
         if dr[0] == 'p':
             rerun = rerun.replace(dr + '_', '')
 
+    # Creates a requests session
+    session = requests.Session()
+    session.auth = (archive.archive._username, archive.archive._password)
+
     # Get temporary directory for dowloading and staging
     if tmp_dir is None:
         tmp_dir = tempfile.mkdtemp()
@@ -379,7 +384,7 @@ def hsc_cutout_bulk_download(table, cutout_size=10.0 * u.Unit('arcsec'),
                                url=archive.archive.img_url,
                                tmp_dir=tmp_dir,
                                output_dir=output_dir,
-                               session=archive.session)
+                               session=session)
     with Pool(nproc) as pool:
         res = pool.map(download_cutouts, batch_files)
 

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -261,8 +261,12 @@ def hsc_cutout(coord, coord_2=None, cutout_size=10.0 * u.Unit('arcsec'), filters
     return cutout_list
 
 def _download_cutouts(args, url=None, filters=None, tmp_dir=None,
-                      session=None):
+                      auth=None):
     list_table, ids, batch_index = args
+
+    session = requests.Session()
+    session.auth = auth
+
     # Download batches for all bands
     output_paths = {}
     for filt in filters:
@@ -343,8 +347,7 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
             rerun = rerun.replace(dr + '_', '')
 
     # Creates a requests session
-    session = requests.Session()
-    session.auth = (archive.archive._username, archive.archive._password)
+    auth = (archive.archive._username, archive.archive._password)
 
     # Get temporary directory for dowloading and staging
     if tmp_dir is None:
@@ -408,7 +411,7 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
                                url=archive.archive.img_url,
                                tmp_dir=tmp_dir,
                                filters=filter_list,
-                               session=session)
+                               auth=auth)
 
     #  Downloading mutliple batches of data in parallel
     print("Starting download of %d batches ..."%n_batches)

--- a/unagi/task.py
+++ b/unagi/task.py
@@ -266,6 +266,7 @@ def _download_cutouts(args, url=None, filters=None, tmp_dir=None,
     # Download batches for all bands
     output_paths = {}
     for filt in filters:
+        print('Download filter %s for batch %d'%(filt, batch_index))
         list_table['filter'] = filt
 
         # Saving download file to folder
@@ -349,6 +350,9 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
     if tmp_dir is None:
         tmp_dir = tempfile.mkdtemp()
 
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
     output_filename = os.path.join(output_dir, 'cutouts_%s_%s_%s.hdf'%(dr, rerun, img_type))
     if not overwrite:
         assert not os.path.isfile(output_filename), "Output file already exists: %s"%output_filename
@@ -400,10 +404,6 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
         batches.append((list_table, ids, batch_index))
 
     # Step 2: Download fits files
-    for f in filters:
-        directory = os.path.join(output_dir, archive._check_filter(f))
-        if not os.path.exists(directory):
-            os.makedirs(directory)
     download_cutouts = partial(_download_cutouts,
                                url=archive.archive.img_url,
                                tmp_dir=tmp_dir,
@@ -411,7 +411,7 @@ def hsc_bulk_cutout(table, cutout_size=10.0 * u.Unit('arcsec'),
                                session=session)
 
     #  Downloading mutliple batches of data in parallel
-    print("Downloading files...")
+    print("Starting download of %d batches ..."%n_batches)
     with Pool(nproc) as pool:
         temp_files = pool.map(download_cutouts, batches)
     print("Download finalized, aggregating cutouts.")


### PR DESCRIPTION
This PR aims to address #13 by adding a bulk download function in the unagi.task

The code I have right now is in part inspired by previous scripts I had and  the code put together by @kstorey. It will download a bunch a of postage stamps but there are some design choices I could use some feedback on:

  - In my current strategy, postage stamps will be saved in the following directory structure:
     output_dir/<hsc filter>/<object_id>.fits

  @dr-guangtou what do you think? it's not compatible with the current format of saving the postage stamps by default, and assumes that each postage stamp corresponds to an object_id, is that fair or too restrictive?
