### PR TITLE
New matplotlib version doesn't support `mpl.cm`

### DIFF
--- a/unagi/plotting.py
+++ b/unagi/plotting.py
@@ -27,7 +27,7 @@ __all__ = ['FILTERS_COLOR', 'plot_skyobj_hist', 'map_skyobjs', 'random_cmap',
            'cutout_show_objects', 'setup']
 
 # Default colormaps
-IMG_CMAP = copy.copy(mpl.cm.get_cmap("viridis"))
+IMG_CMAP = copy.copy(plt.cm.get_cmap("viridis"))
 IMG_CMAP.set_bad(color='black')
 
 FILTERS_COLOR = ['#2ca02c', '#ff7f0e', '#d62728', '#8c564b', '#7f7f7f']


### PR DESCRIPTION
I noticed that matplotlib v3.3.4 no longer supports `mpl.cm`. So I changed it to `plt.cm`.