### PR TITLE
Adds tool to download PSFs in bulk

### DIFF
--- a/unagi/task.py
+++ b/unagi/task.py
@@ -564,6 +564,172 @@ def hsc_psf(coord, centered=True, filters='i', dr='dr2', rerun='s18a_wide',
 
     return psf_list
 
+# 5 Attempts at downloading the batch, waiting between 5 and 30s between attempts
+@retry(wait=wait_random(min=5, max=30), stop=stop_after_attempt(5))
+def _download_psf(args, url=None, filters=None, tmp_dir=None, auth=None):
+    list_table, ids, batch_index = args
+
+    session = requests.Session()
+    session.auth = auth
+
+    output_file = os.path.join(tmp_dir, 'batch_psf_%d.hdf'%batch_index)
+    # Check if output cutout file exists, if it does, we are good
+    if os.path.isfile(output_file):
+        print('Found cutout file for batch file %d, skipping download'%batch_index)
+        return output_file
+
+    # Download batches for all bands
+    output_paths = {}
+    for filt in filters:
+        print('Download PSF for filter %s for batch %d'%(filt, batch_index))
+        list_table['filter'] = filt
+
+        # Saving download file to folder
+        filename = os.path.join(tmp_dir, ('batch_%s_%d')%(filt, batch_index))
+        list_table.write(filename, format='ascii.tab')
+
+        # Request download
+        resp = session.post(url, files={'list': open(filename, 'rb')}, stream=True)
+
+        # Checking that access worked after number of retries
+        assert resp.status_code == 200
+        tar_filename = resp.headers['Content-Disposition'].split('"')[-2]
+
+        # Proceed to download the data
+        with open(os.path.join(tmp_dir, tar_filename), 'wb') as f:
+            for chunk in resp.iter_content(chunk_size=1024):
+                f.write(chunk)
+        
+        
+        output_path = os.path.join(tmp_dir, tar_filename.split('.tar')[0])
+        
+        # Untar the archive and remove file
+        with tarfile.TarFile(os.path.join(tmp_dir, tar_filename), "r") as tarball:
+            tarball.extractall(os.path.join(tmp_dir, tar_filename.split('.tar')[0]))
+ 
+        # Removing tar file after extraction
+        os.remove(filename)
+        os.remove(os.path.join(tmp_dir, tar_filename))
+        
+        
+        # Recover path to output dir
+        output_paths[filt] = output_path
+        # Transform each file into an HDFFITS format, named based on the object ids
+        fnames = glob.glob(output_path+'/*.fits')
+        for fname in fnames:
+            indx = int(fname.split(output_path+'/')[1].split('-')[0]) - 2
+            output_filename = os.path.join(output_path, '%d.hdf'%ids[indx])
+            a = read_fits(fname)
+            export_hdf(a, output_filename)
+            # Removing converted file
+            os.remove(fname)
+
+    # At this stage all filters have been  downloaded for this batch, now
+    # aggregating all of them into a single HDF file
+    with h5py.File(output_file, mode='w') as d:
+        for ii in ids:
+            for f in filters:
+                with h5py.File( os.path.join(output_paths[f], '{:d}.hdf'.format(ii)), mode='r+') as s:
+                    d.copy(s, '%d/%s'%(ii,f))
+
+    # For good measure, remove all temporary directory
+    for f in filters:
+        shutil.rmtree(output_paths[f])
+
+    return output_file
+
+
+def hsc_bulk_psf(table,
+                 filters='i', dr='dr2', rerun='s18a_wide', 
+                 img_type='coadd', verbose=True, archive=None,
+                 nproc=1,
+                 tmp_dir=None, 
+                 output_dir='./', overwrite=False, **kwargs):
+    """
+    Generate HSC psf images in bulk.
+    table: astropy table
+        Astropy table of with at least object_id, and (ra, dec) in deg.
+    """
+    # Login to HSC archive
+    if archive is None:
+        archive = Hsc(dr=dr, rerun=rerun)
+    else:
+        dr = archive.dr
+        rerun = archive.rerun
+        if dr[0] == 'p':
+            rerun = rerun.replace(dr + '_', '')
+
+    # Creates a requests session
+    auth = (archive.archive._username, archive.archive._password)
+
+    # Get temporary directory for dowloading and staging
+    if tmp_dir is None:
+        tmp_dir = tempfile.mkdtemp()
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    output_filename = os.path.join(output_dir, 'psfs_%s_%s_%s.hdf'%(dr, rerun, img_type))
+    if not overwrite:
+        assert not os.path.isfile(output_filename), "Output file already exists: %s"%output_filename
+
+    # Ensure correct filters
+    filter_list = list(filters)
+    filter_list = [archive._check_filter(f) for f in filter_list]
+
+    # Check the choices of filters
+    assert np.all(
+        [(f in archive.FILTER_SHORT) or (f in archive.FILTER_LIST)
+         for f in filter_list]), '# Wrong filter choice!'
+
+    # Compute the number of batches to download
+    # There is a hard limit of 1000 cutouts at a time
+    batch_size = 1000
+    n_batches = len(table) // batch_size
+    if len(table) % batch_size > 0:
+        n_batches = n_batches + 1
+
+    # Step 1: Create batches of object ids and coordinates
+    batches = []
+    for batch_index in range(n_batches):
+        list_table = table[['ra', 'dec', 'object_id']][
+            batch_index*batch_size:(batch_index+1)*batch_size]
+        list_table['rerun'] = archive.rerun
+        list_table['filter'] = archive._check_filter(filters[0])
+        list_table['type'] = img_type
+        list_table['#?'] = ''
+        # Saving object ids corresponding to the downloaded objects
+        ids = list_table['object_id']
+        list_table = list_table[
+            ['#?', 'ra', 'dec', 'object_id', 'filter', 'type', 'rerun']]
+        batches.append((list_table, ids, batch_index))
+
+    # Step 2: Download fits files
+    download_psf = partial(_download_psf,
+                            url=archive.archive.psf_url+'bulk=on',
+                            tmp_dir=tmp_dir,
+                            filters=filter_list,
+                            auth=auth)
+
+    #  Downloading mutliple batches of data in parallel
+    print("Starting download of %d batches ..."%n_batches)
+    with Pool(nproc) as pool:
+        temp_files = pool.map(download_psf, batches, chunksize=1)
+    print("Download finalized, aggregating cutouts.")
+
+    # At this point, we have a bunch of individual HDF files, we just need to
+    # merge them back together
+    with h5py.File(output_filename, 'w') as d:
+        for f in temp_files:
+            with h5py.File(f,'r') as s:
+                for k in s.keys():
+                    d.copy(s[k], '/'+k)
+            # Now that everything is done, remove temporary hdf file
+            os.remove(f)
+
+    return output_filename
+
+
 def hsc_cone_search(coord, radius=10.0 * u.Unit('arcsec'), redshift=None,
                     archive=None, dr='pdr2', rerun='pdr2_wide', cosmo=None,
                     verbose=True, **kwargs):


### PR DESCRIPTION
Hi @dr-guangtou :-) this PR adds a functionality to download PSFs in bulk from the psf service, similar to the download of cutouts in bulk I already had added a long time ago. It generates an HDF file with entries corresponding to the PSF at the position of desired objects.

The way it works is following:
```python
# Do some query to get a catalog of objects with at least ra,dec, and object_id
catalog = archive.sql_query(query, from_file=False, verbose=True)
filters = ['HSC-I']
tmp_dir='tmp_dir'
out_dir='./'
!mkdir -p tmp_dir

psfs_filename = task.hsc_bulk_psf(catalog, 
                                  filters=filters, 
                                  archive=archive,  
                                  tmp_dir=tmp_dir,
                                  output_dir=out_dir)

psfs = h5py.File(psfs_filename, 'r')
```

It's essentially the same as for the bulk cutouts download.